### PR TITLE
0.0.4 - fixed newlines in event data

### DIFF
--- a/gkm.js
+++ b/gkm.js
@@ -10,7 +10,7 @@ var events = new EventEmitter2({wildcard: true});
 var gkm = spawn('java', ['-jar', path.join(__dirname, 'lib/gkm.jar')]);
 
 gkm.stdout.on('data', function(data) {
-	data = data.toString().split(/\r\n/).filter(function(item) { return item; });
+	data = data.toString().split(/\r\n|\r|\n/).filter(function(item) { return item; });
 	for (var i in data) {
 		var parts = data[i].split(':');
 		events.emit(parts[0], parts.slice(1));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gkm",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Global Keyboard and Mouse listener",
   "keywords": [
     "global",


### PR DESCRIPTION
Fixed newlines appearing in event data on platforms that do not use carriage return line feeds. #2

Needs merge & npm publish.